### PR TITLE
Add support for arm64 macs and Python 3.11, switch to calver

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,14 +47,40 @@ jobs:
           name: wheelhouse
           path: ./wheelhouse/*.whl
 
-  # To trigger a release, push a tag:
+  # Ensure that wheel file names in README.md match file names from build
+  check-filenames:
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheelhouse
+      - uses: softprops/action-gh-release@v0.1.14
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: '*.whl'
+      - run: |
+          echo ${{ github.ref }}
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            release=$(echo "${{ github.ref }}" | cut -d/ -f3)
+            regex="https://github.com/Akuli/py-tree-sitter-builds/releases/download/$release/[^/ ]*\.whl"
+          else
+            regex="https://github.com/Akuli/py-tree-sitter-builds/releases/download/v[^/ ]*/[^/ ]*\.whl"
+          fi
+          echo "$regex"
+          grep -oE "$regex" README.md | xargs basename -a | sort | uniq > readme_filenames.txt
+          printf "%s\n" *.whl | sort | uniq > build_filenames.txt
+          diff -u --color=always readme_filenames.txt build_filenames.txt
+
+  # To trigger a release, push a calver-style tag:
   #
-  #   $ git tag v0.20.0   # take first two numbers from py-tree-sitter version
+  #   $ git tag v$(date +%Y-%m-%d)
   #   $ git push --tags origin
   release:
     runs-on: ubuntu-latest
     # https://stackoverflow.com/a/58478262
-    needs: [build]
+    needs: [check-filenames]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
   #   $ git add README.md
   #   $ git commit -m "Replace new version to README"
   #   $ git tag v$(date +%Y-%m-%d)
-  #   $ git push --tags origin
+  #   $ git push --tags origin main
   release:
     runs-on: ubuntu-latest
     # https://stackoverflow.com/a/58478262

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,8 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: wheelhouse
-      - run: |
+      - name: Get file names from README to text file
+        run: |
           echo ${{ github.ref }}
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             release=$(echo "${{ github.ref }}" | cut -d/ -f3)
@@ -65,8 +66,9 @@ jobs:
           fi
           echo "$regex"
           grep -oE "$regex" README.md | xargs basename -a | sort | uniq > readme_filenames.txt
+      - run: |
           printf "%s\n" *.whl | sort | uniq > build_filenames.txt
-          diff -u --color=always readme_filenames.txt build_filenames.txt
+      - run: diff -u --color=always readme_filenames.txt build_filenames.txt
 
   # To trigger a release, push a calver-style tag:
   #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
           grep -oE "$regex" README.md | xargs basename -a | sort | uniq > readme_filenames.txt
       - name: Get list of relevant wheel file names built
         run: |
-          printf "%s\n" *.whl | grep -vE 'pypy|musllinux' | sort | uniq > build_filenames.txt
+          printf "%s\n" *.whl | grep -vE 'pypy|musllinux' | sort > build_filenames.txt
       - run: diff -u --color=always readme_filenames.txt build_filenames.txt
 
   # To trigger a release, push a calver-style tag:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
 
   # Ensure that wheel file names in README.md match file names from build
   check-filenames:
+    runs-on: ubuntu-20.04
     needs: [build]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,8 +66,9 @@ jobs:
           fi
           echo "$regex"
           grep -oE "$regex" README.md | xargs basename -a | sort | uniq > readme_filenames.txt
-      - run: |
-          printf "%s\n" *.whl | sort | uniq > build_filenames.txt
+      - name: Get list of relevant wheel file names built
+        run: |
+          printf "%s\n" *.whl | grep -vE 'pypy|musllinux' | sort | uniq > build_filenames.txt
       - run: diff -u --color=always readme_filenames.txt build_filenames.txt
 
   # To trigger a release, push a calver-style tag:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
           name: wheelhouse
       - name: Get file names from README to text file
         run: |
-          echo ${{ github.ref }}
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
             release=$(echo "${{ github.ref }}" | cut -d/ -f3)
             regex="https://github.com/Akuli/py-tree-sitter-builds/releases/download/$release/[^/ ]*\.whl"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,11 +55,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: wheelhouse
-      - uses: softprops/action-gh-release@v0.1.14
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: '*.whl'
       - run: |
           echo ${{ github.ref }}
           if [[ "${{ github.ref }}" == refs/tags/v* ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,8 +71,11 @@ jobs:
           printf "%s\n" *.whl | grep -vE 'pypy|musllinux' | sort > build_filenames.txt
       - run: diff -u --color=always readme_filenames.txt build_filenames.txt
 
-  # To trigger a release, push a calver-style tag:
+  # To trigger a release:
   #
+  #   $ sed -i s/v20[0-9][0-9]\.[0-9][0-9]\.[0-9][0-9]/v$(date +%Y-%m-%d)/g README.md
+  #   $ git add README.md
+  #   $ git commit -m "Replace new version to README"
   #   $ git tag v$(date +%Y-%m-%d)
   #   $ git push --tags origin
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
       - run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_TEST_COMMAND: python -m unittest discover -s {project}/tests
+          CIBW_ARCHS_MACOS: x86_64 arm64
       - uses: actions/upload-artifact@v2
         with:
           name: wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         run: script\fetch-fixtures.cmd
       - if: ${{ !startsWith(matrix.os, 'windows') }}
         run: script/fetch-fixtures
-      - run: pip install cibuildwheel==2.5.0
+      - run: pip install cibuildwheel==2.9.0
       - run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_TEST_COMMAND: python -m unittest discover -s {project}/tests

--- a/README.md
+++ b/README.md
@@ -39,35 +39,39 @@ you should realistically just wait until something is properly published on PyPI
 ```
 # Install py-tree-sitter 0.20.0 from github.com/Akuli/py-tree-sitter-builds.
 # 32-bit linux
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.6' and sys_platform == 'linux' and platform_machine == 'i686'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.7' and sys_platform == 'linux' and platform_machine == 'i686'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'i686'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'i686'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.6' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.7' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'i686'
 # 64-bit linux
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.6' and sys_platform == 'linux' and platform_machine == 'x86_64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.7' and sys_platform == 'linux' and platform_machine == 'x86_64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'x86_64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'x86_64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.6' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.7' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'x86_64'
 # 32-bit windows
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp36-cp36m-win32.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'x86'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp37-cp37m-win32.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'x86'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp38-cp38-win32.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'x86'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp39-cp39-win32.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'x86'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp310-cp310-win32.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-win32.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-win32.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-win32.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-win32.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-win32.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'x86'
 # 64-bit windows
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp36-cp36m-win_amd64.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'AMD64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'AMD64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'AMD64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'AMD64'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'AMD64'
-# 64-bit MacOS. Works only on Intel CPU or under Intel emulation on arm64 macs.
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp36-cp36m-macosx_10_9_x86_64.whl ; python_version == '3.6' and sys_platform == 'darwin'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp37-cp37m-macosx_10_9_x86_64.whl ; python_version == '3.7' and sys_platform == 'darwin'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp38-cp38-macosx_10_9_x86_64.whl ; python_version == '3.8' and sys_platform == 'darwin'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp39-cp39-macosx_10_9_x86_64.whl ; python_version == '3.9' and sys_platform == 'darwin'
-tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v0.20.0/tree_sitter-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl ; python_version == '3.10' and sys_platform == 'darwin'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-win_amd64.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'AMD64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'AMD64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'AMD64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'AMD64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'AMD64'
+# 64-bit Intel Mac
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-macosx_10_9_x86_64.whl ; python_version == '3.6' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-macosx_10_9_x86_64.whl ; python_version == '3.7' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-macosx_10_9_x86_64.whl ; python_version == '3.8' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-macosx_10_9_x86_64.whl ; python_version == '3.9' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl ; python_version == '3.10' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+# M1 Mac
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-macosx_11_0_arm64.whl ; python_version == '3.8' and sys_platform == 'darwin' and platform_machine == 'arm64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-macosx_11_0_arm64.whl ; python_version == '3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-macosx_11_0_arm64.whl ; python_version == '3.10' and sys_platform == 'darwin' and platform_machine == 'arm64'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ This project is currently not published to PyPI, so installation is a bit of a m
     - 64-bit Intel CPU (`x86_64`, if you are not sure try `import platform; print(platform.machine())`)
 
     you would choose `tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.
-    On newer arm64 Macs, choose either `x86_64` or `arm64` depending on which kind of Python you have
-    (try `print(platform.machine())`).
 
 2. Run `pip install path/to/downloaded/file.whl`, for example `pip install Downloads/tree_sitter-0.20.0-cp39-cp39-musllinux_1_1_x86_64.whl`.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ This project is currently not published to PyPI, so installation is a bit of a m
     - 64-bit Intel CPU (`x86_64`)
 
     you would choose `tree_sitter-0.20.0-cp39-cp39-musllinux_1_1_x86_64.whl`.
+    On newer arm64 Macs, choose either `x86_64` or `arm64` depending on which kind of Python you have
+    (try `print(platform.machine())`).
 
 2. Run `pip install path/to/downloaded/file.whl`, for example `pip install Downloads/tree_sitter-0.20.0-cp39-cp39-musllinux_1_1_x86_64.whl`.
 
@@ -81,9 +83,6 @@ tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v
 ```
 
 </details>
-
-Newer, arm-based macs are supported only if you use Python compiled for Intel (x86_64) processors.
-If this is a problem for you, please create an issue.
 
 
 ## How does it work?

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project is currently not published to PyPI, so installation is a bit of a m
 
     you would choose `tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.
 
-2. Run `pip install path/to/downloaded/file.whl`, for example `pip install Downloads/tree_sitter-0.20.0-cp39-cp39-musllinux_1_1_x86_64.whl`.
+2. Run `pip install path/to/downloaded/file.whl`, for example `pip install Downloads/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.
 
 For a more permanent solution, I will probably publish this project on PyPI
 unless the py-tree-sitter maintainers are interested in making this a part of the official `py-tree-sitter` repository.

--- a/README.md
+++ b/README.md
@@ -44,34 +44,40 @@ tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'i686'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'i686'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'i686'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl ; python_version == '3.11' and sys_platform == 'linux' and platform_machine == 'i686'
 # 64-bit linux
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.6' and sys_platform == 'linux' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.7' and sys_platform == 'linux' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.8' and sys_platform == 'linux' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.9' and sys_platform == 'linux' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.10' and sys_platform == 'linux' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl ; python_version == '3.11' and sys_platform == 'linux' and platform_machine == 'x86_64'
 # 32-bit windows
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-win32.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'x86'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-win32.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'x86'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-win32.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'x86'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-win32.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'x86'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-win32.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'x86'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-win32.whl ; python_version == '3.11' and sys_platform == 'win32' and platform_machine == 'x86'
 # 64-bit windows
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-win_amd64.whl ; python_version == '3.6' and sys_platform == 'win32' and platform_machine == 'AMD64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-win_amd64.whl ; python_version == '3.7' and sys_platform == 'win32' and platform_machine == 'AMD64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-win_amd64.whl ; python_version == '3.8' and sys_platform == 'win32' and platform_machine == 'AMD64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-win_amd64.whl ; python_version == '3.9' and sys_platform == 'win32' and platform_machine == 'AMD64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-win_amd64.whl ; python_version == '3.10' and sys_platform == 'win32' and platform_machine == 'AMD64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-win_amd64.whl ; python_version == '3.11' and sys_platform == 'win32' and platform_machine == 'AMD64'
 # 64-bit Intel Mac
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp36-cp36m-macosx_10_9_x86_64.whl ; python_version == '3.6' and sys_platform == 'darwin' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp37-cp37m-macosx_10_9_x86_64.whl ; python_version == '3.7' and sys_platform == 'darwin' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-macosx_10_9_x86_64.whl ; python_version == '3.8' and sys_platform == 'darwin' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-macosx_10_9_x86_64.whl ; python_version == '3.9' and sys_platform == 'darwin' and platform_machine == 'x86_64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-macosx_10_9_x86_64.whl ; python_version == '3.10' and sys_platform == 'darwin' and platform_machine == 'x86_64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-macosx_10_9_x86_64.whl ; python_version == '3.11' and sys_platform == 'darwin' and platform_machine == 'x86_64'
 # M1 Mac
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp38-cp38-macosx_11_0_arm64.whl ; python_version == '3.8' and sys_platform == 'darwin' and platform_machine == 'arm64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp39-cp39-macosx_11_0_arm64.whl ; python_version == '3.9' and sys_platform == 'darwin' and platform_machine == 'arm64'
 tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp310-cp310-macosx_11_0_arm64.whl ; python_version == '3.10' and sys_platform == 'darwin' and platform_machine == 'arm64'
+tree-sitter @ https://github.com/Akuli/py-tree-sitter-builds/releases/download/v2022-08-24/tree_sitter-0.20.0-cp311-cp311-macosx_11_0_arm64.whl ; python_version == '3.11' and sys_platform == 'darwin' and platform_machine == 'arm64'
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is currently not published to PyPI, so installation is a bit of a m
     For example, if you have:
     - Python 3.9 installation (`cp39`)
     - A typical Linux distribution (`manylinux`)
-    - 64-bit Intel CPU (`x86_64`)
+    - 64-bit Intel CPU (`x86_64`, if you are not sure try `import platform; print(platform.machine())`)
 
     you would choose `tree_sitter-0.20.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl`.
     On newer arm64 Macs, choose either `x86_64` or `arm64` depending on which kind of Python you have


### PR DESCRIPTION
- [x] Update README with `platform_machine == 'x86_64'` or `platform_machine == 'arm64'` or the like